### PR TITLE
missing gene-column error fix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -476,7 +476,7 @@ fn main() {
 
     let mut dataset = read_transcripts_csv(
         &args.transcript_csv,
-        &expect_arg(args.gene_column, "transcript-column"),
+        &expect_arg(args.gene_column, "gene-column"),
         args.transcript_id_column,
         args.compartment_column,
         args.compartment_nuclear,


### PR DESCRIPTION
Change error message with missing gene-column to "Missing required argument: --gene-column" instead of "Missing required argument: --transcript-column"