### PR TITLE
Update main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -414,10 +414,10 @@ fn set_cosmx_presets(args: &mut Args) {
     args.cell_assignment_unassigned
         .get_or_insert(String::from("0"));
     args.excluded_genes
-        .get_or_insert(String::from("^(FalseCode|NegPrb)"));
+        .get_or_insert(String::from("^(FalseCode|SystemControl|NegPrb|Negative)"));
 
-    // CosMx reports values in pixels and pixel size appears to always be 0.12 microns.
-    args.coordinate_scale.get_or_insert(0.12);
+    // CosMx reports values in pixels and pixel size appears to always be 0.12028 microns.
+    args.coordinate_scale.get_or_insert(0.12028);
 }
 
 fn set_cosmx_micron_presets(args: &mut Args) {
@@ -433,7 +433,7 @@ fn set_cosmx_micron_presets(args: &mut Args) {
     args.cell_id_column.get_or_insert(String::from("cell_ID"));
     args.cell_id_unassigned.get_or_insert(String::from("0"));
     args.excluded_genes
-        .get_or_insert(String::from("^(FalseCode|NegPrb)"));
+        .get_or_insert(String::from("^(FalseCode|SystemControl|NegPrb|Negative)"));
 }
 
 fn set_merfish_presets(args: &mut Args) {


### PR DESCRIPTION
Updated regex for CosMx FalseCode and NegPrb to include current naming convention (SystemControl and Negative, respectively), as these weren't being filtered out correctly for new datasets. Additionally updated the pixel resolution for CosMx, which is 0.12028um/px